### PR TITLE
compiler fixes

### DIFF
--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/jobgen/QueryLogicalExpressionJobGen.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/jobgen/QueryLogicalExpressionJobGen.java
@@ -23,8 +23,10 @@ import java.util.List;
 import org.apache.asterix.common.api.IApplicationContext;
 import org.apache.asterix.common.config.CompilerProperties;
 import org.apache.asterix.common.functions.FunctionDescriptorTag;
+import org.apache.asterix.common.functions.FunctionSignature;
 import org.apache.asterix.external.library.ExternalFunctionDescriptorProvider;
 import org.apache.asterix.metadata.declared.MetadataProvider;
+import org.apache.asterix.metadata.entities.Function;
 import org.apache.asterix.om.functions.BuiltinFunctions;
 import org.apache.asterix.om.functions.IExternalFunctionInfo;
 import org.apache.asterix.om.functions.IFunctionDescriptor;
@@ -66,7 +68,14 @@ public class QueryLogicalExpressionJobGen implements ILogicalExpressionJobGen {
             IVariableTypeEnvironment env, IOperatorSchema[] inputSchemas, JobGenContext context)
             throws AlgebricksException {
         IScalarEvaluatorFactory[] args = codegenArguments(expr, env, inputSchemas, context);
-        IFunctionDescriptor fd = resolveFunction(expr, env, context);
+        IFunctionDescriptor fd;
+        Function uda = ((MetadataProvider) context.getMetadataProvider())
+                .lookupUserDefinedFunction(new FunctionSignature(expr.getFunctionIdentifier()));
+        if (uda != null) {
+            fd = ExternalFunctionDescriptorProvider.resolveExternalFunction(expr, env, context);
+        } else {
+            fd = resolveFunction(expr, env, context);
+        }
         switch (fd.getFunctionDescriptorTag()) {
             case SERIALAGGREGATE:
                 return null;

--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/base/FunctionUtils.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/base/FunctionUtils.java
@@ -1,0 +1,45 @@
+package org.apache.asterix.optimizer.base;
+
+import java.util.List;
+
+import org.apache.asterix.common.functions.FunctionSignature;
+import org.apache.asterix.metadata.declared.MetadataProvider;
+import org.apache.asterix.metadata.functions.ExternalFunctionCompilerUtil;
+import org.apache.asterix.om.functions.BuiltinFunctions;
+import org.apache.commons.lang3.mutable.Mutable;
+import org.apache.hyracks.algebricks.common.exceptions.AlgebricksException;
+import org.apache.hyracks.algebricks.core.algebra.base.ILogicalExpression;
+import org.apache.hyracks.algebricks.core.algebra.expressions.AbstractFunctionCallExpression;
+import org.apache.hyracks.algebricks.core.algebra.expressions.AggregateFunctionCallExpression;
+import org.apache.hyracks.algebricks.core.algebra.functions.FunctionIdentifier;
+import org.apache.hyracks.algebricks.core.algebra.functions.IFunctionInfo;
+
+public class FunctionUtils {
+
+    public static FunctionIdentifier getBuiltinAggOrUDF(AbstractFunctionCallExpression fc, MetadataProvider mdPv)
+            throws AlgebricksException {
+        //TODO: some way to avoid this FunctionSignature dance?
+        FunctionIdentifier fid = fc.getFunctionIdentifier();
+        FunctionSignature fSig =
+                new FunctionSignature(FunctionSignature.getDataverseName(fid), "agg-" + fid.getName(), fid.getArity());
+        org.apache.asterix.metadata.entities.Function udf = mdPv.lookupUserDefinedFunction(fSig);
+        if (udf != null) {
+            return udf.getSignature().createFunctionIdentifier();
+        } else
+            return BuiltinFunctions.getAggregateFunction(fc.getFunctionIdentifier());
+    }
+
+    public static AggregateFunctionCallExpression getBuiltinAggExprOrUDF(FunctionIdentifier fi,
+            List<Mutable<ILogicalExpression>> args, MetadataProvider mdPv) throws AlgebricksException {
+        FunctionSignature fSig = new FunctionSignature(fi);
+        org.apache.asterix.metadata.entities.Function udf = mdPv.lookupUserDefinedFunction(fSig);
+        if (udf != null) {
+            IFunctionInfo finfo = ExternalFunctionCompilerUtil.getExternalFunctionInfo(mdPv, udf);
+            AggregateFunctionCallExpression expr = new AggregateFunctionCallExpression(finfo, true, args);
+            expr.setStepOneAggregate(finfo);
+            expr.setStepTwoAggregate(finfo);
+            return expr;
+        } else
+            return BuiltinFunctions.makeAggregateFunctionExpression(fi, args);
+    }
+}

--- a/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/IntroduceDynamicTypeCastForExternalFunctionRule.java
+++ b/asterixdb/asterix-algebra/src/main/java/org/apache/asterix/optimizer/rules/IntroduceDynamicTypeCastForExternalFunctionRule.java
@@ -72,6 +72,11 @@ public class IntroduceDynamicTypeCastForExternalFunctionRule implements IAlgebra
         if (BuiltinFunctions.getBuiltinFunctionInfo(funcCallExpr.getFunctionIdentifier()) != null) {
             return changed;
         }
+        // if the function is an aggregate, skip.
+        if (((ExternalFunctionInfo) funcCallExpr.getFunctionInfo())
+                .getKind() == AbstractFunctionCallExpression.FunctionKind.AGGREGATE) {
+            return changed;
+        }
         IAType inputType;
         IAType reqArgType;
         boolean castFlag;

--- a/asterixdb/asterix-app/src/main/java/org/apache/asterix/app/translator/QueryTranslator.java
+++ b/asterixdb/asterix-app/src/main/java/org/apache/asterix/app/translator/QueryTranslator.java
@@ -2925,6 +2925,14 @@ public class QueryTranslator extends AbstractLangTranslator implements IStatemen
                 String functionKind =
                         cfs.getIsAggregate() ? FunctionKind.AGGREGATE.toString() : FunctionKind.SCALAR.toString();
 
+                Function realAggFunction = new Function(
+                        new FunctionSignature(functionSignature.getDataverseName(),
+                                "agg-" + functionSignature.getName(), functionSignature.getArity()),
+                        paramNames, paramTypes, returnTypeSignature, null, functionKind, library.getLanguage(),
+                        libraryDataverseName, libraryName, externalIdentifier, cfs.getNullCall(),
+                        cfs.getDeterministic(), cfs.getResources(), dependencies);
+                MetadataManager.INSTANCE.addFunction(mdTxnCtx, realAggFunction);
+
                 function = new Function(functionSignature, paramNames, paramTypes, returnTypeSignature, null,
                         functionKind, library.getLanguage(), libraryDataverseName, libraryName, externalIdentifier,
                         cfs.getNullCall(), cfs.getDeterministic(), cfs.getResources(), dependencies);

--- a/asterixdb/asterix-app/src/test/resources/TweetSent/sentiment.py
+++ b/asterixdb/asterix-app/src/test/resources/TweetSent/sentiment.py
@@ -32,3 +32,17 @@ class TweetSent(object):
         if args is None:
             return 2
         return self.pipeline.predict([args])[0].item()
+
+
+class Count(object):
+
+    count = 0
+    def init(self):
+        return
+
+    def step(self, arg):
+        self.count = self.count +1
+        return self.count
+
+    def finish(self):
+        return self.count

--- a/asterixdb/asterix-app/src/test/resources/log4j2-asterixdb-test.xml
+++ b/asterixdb/asterix-app/src/test/resources/log4j2-asterixdb-test.xml
@@ -32,6 +32,7 @@
     <Root level="WARN">
       <AppenderRef ref="InfoLog"/>
     </Root>
+
     <Logger name="org.apache.hyracks.control.nc.service" level="INFO"/>
     <Logger name="org.apache.hyracks" level="INFO"/>
     <Logger name="org.apache.asterix" level="INFO"/>

--- a/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ExternalAggregatePythonFunctionEvaluator.java
+++ b/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ExternalAggregatePythonFunctionEvaluator.java
@@ -127,6 +127,7 @@ class ExternalAggregatePythonFunctionEvaluator extends ExternalAggregateFunction
         try {
             ByteBuffer res = libraryEvaluator.callPython(stepFnId, argTypes, argValues, nullCall);
             resultBuffer.reset();
+//            wrap(res, resultBuffer.getDataOutput());
         } catch (Exception e) {
             throw new HyracksDataException("Error evaluating Python UDF", e);
         }
@@ -178,7 +179,7 @@ class ExternalAggregatePythonFunctionEvaluator extends ExternalAggregateFunction
             }
             int numresults = resultWrapper.get() ^ FIXARRAY_PREFIX;
             if (numresults > 0) {
-                unpackerToADM.unpack(resultWrapper, out, true);
+                unpackerToADM.unpack(resultWrapper, out, false);
             }
             unpackerInput.reset(resultWrapper.array(), resultWrapper.position() + resultWrapper.arrayOffset(),
                     resultWrapper.remaining());

--- a/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ExternalAggregatePythonFunctionEvaluator.java
+++ b/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ExternalAggregatePythonFunctionEvaluator.java
@@ -156,10 +156,11 @@ class ExternalAggregatePythonFunctionEvaluator extends ExternalAggregateFunction
         int lastIndex = newIdentifiers.size() - 1;
         String newIdentifier = newIdentifiers.get(lastIndex) + "." + functionName;
         newIdentifiers.set(lastIndex, newIdentifier);
+        //TODO: isprivate?
         return new ExternalFunctionInfo(finfo.getFunctionIdentifier(), finfo.getKind(), finfo.getParameterTypes(),
                 finfo.getReturnType(), finfo.getResultTypeComputer(), finfo.getLanguage(),
                 finfo.getLibraryDataverseName(), finfo.getLibraryName(), newIdentifiers, finfo.getResources(),
-                finfo.isFunctional(), finfo.getNullCall());
+                finfo.isFunctional(), finfo.getNullCall(), false);
     }
 
     private void wrap(ByteBuffer resultWrapper, DataOutput out) throws HyracksDataException {

--- a/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ExternalFunctionDescriptorProvider.java
+++ b/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ExternalFunctionDescriptorProvider.java
@@ -47,15 +47,16 @@ public class ExternalFunctionDescriptorProvider {
             case SCALAR:
                 return new ExternalScalarFunctionDescriptor(finfo);
             case AGGREGATE:
-                return new ScalarExternalAggregateDescriptor(new ExternalAggregateFunctionDescriptorFactory(finfo));
+                //TODO: !!!!!FILTHY, WRETCHED HACK
+                if (finfo.getFunctionIdentifier().getName().startsWith("agg-")) {
+                    return new ExternalAggregateFunctionDescriptor(finfo);
+                } else {
+                    return new ScalarExternalAggregateDescriptor(new ExternalAggregateFunctionDescriptorFactory(finfo));
+                }
             case UNNEST:
                 throw new AsterixException(ErrorCode.LIBRARY_EXTERNAL_FUNCTION_UNSUPPORTED_KIND, finfo.getKind());
             default:
                 throw new AsterixException(ErrorCode.LIBRARY_EXTERNAL_FUNCTION_UNKNOWN_KIND, finfo.getKind());
         }
-    }
-
-    static IExternalFunctionDescriptor getExternalAggregateFunctionDescriptor(IExternalFunctionInfo fInfo) {
-        return new ExternalScalarFunctionDescriptor(fInfo);
     }
 }

--- a/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ScalarExternalAggregateDescriptor.java
+++ b/asterixdb/asterix-external-data/src/main/java/org/apache/asterix/external/library/ScalarExternalAggregateDescriptor.java
@@ -18,18 +18,12 @@
  */
 package org.apache.asterix.external.library;
 
-import org.apache.asterix.om.functions.*;
+import org.apache.asterix.om.functions.IExternalFunctionDescriptor;
+import org.apache.asterix.om.functions.IExternalFunctionInfo;
+import org.apache.asterix.om.functions.IFunctionDescriptorFactory;
 import org.apache.asterix.om.types.IAType;
 import org.apache.asterix.runtime.aggregates.scalar.AbstractScalarAggregateDescriptor;
-import org.apache.asterix.runtime.unnestingfunctions.std.ScanCollectionDescriptor;
-import org.apache.hyracks.algebricks.common.exceptions.AlgebricksException;
 import org.apache.hyracks.algebricks.core.algebra.functions.FunctionIdentifier;
-import org.apache.hyracks.algebricks.runtime.base.IAggregateEvaluatorFactory;
-import org.apache.hyracks.algebricks.runtime.base.IEvaluatorContext;
-import org.apache.hyracks.algebricks.runtime.base.IScalarEvaluator;
-import org.apache.hyracks.algebricks.runtime.base.IScalarEvaluatorFactory;
-import org.apache.hyracks.algebricks.runtime.evaluators.ColumnAccessEvalFactory;
-import org.apache.hyracks.api.exceptions.HyracksDataException;
 
 public class ScalarExternalAggregateDescriptor extends AbstractScalarAggregateDescriptor
         implements IExternalFunctionDescriptor {

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/functions/ExternalAggregateFunctionInfo.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/functions/ExternalAggregateFunctionInfo.java
@@ -38,6 +38,6 @@ public class ExternalAggregateFunctionInfo extends ExternalFunctionInfo {
             String libraryName, List<String> externalIdentifier, Map<String, String> resources, boolean deterministic,
             boolean nullCall) {
         super(fid, FunctionKind.AGGREGATE, parameterTypes, returnType, rtc, language, libraryDataverseName, libraryName,
-                externalIdentifier, resources, deterministic, nullCall);
+                externalIdentifier, resources, deterministic, nullCall, false);
     }
 }

--- a/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/functions/ExternalScalarFunctionInfo.java
+++ b/asterixdb/asterix-metadata/src/main/java/org/apache/asterix/metadata/functions/ExternalScalarFunctionInfo.java
@@ -38,6 +38,6 @@ public class ExternalScalarFunctionInfo extends ExternalFunctionInfo {
             String libraryName, List<String> externalIdentifier, Map<String, String> resources, boolean deterministic,
             boolean nullCall) {
         super(fid, FunctionKind.SCALAR, parameterTypes, returnType, rtc, language, libraryDataverseName, libraryName,
-                externalIdentifier, resources, deterministic, nullCall);
+                externalIdentifier, resources, deterministic, nullCall, false);
     }
 }

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/om/functions/BuiltinFunctionInfo.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/om/functions/BuiltinFunctionInfo.java
@@ -25,15 +25,9 @@ import org.apache.hyracks.algebricks.core.algebra.functions.FunctionIdentifier;
 public final class BuiltinFunctionInfo extends FunctionInfo {
     private static final long serialVersionUID = -6013109889177637590L;
 
-    private final boolean isPrivate;
-
     public BuiltinFunctionInfo(FunctionIdentifier fi, IResultTypeComputer typeComputer, boolean isFunctional,
             boolean isPrivate) {
-        super(fi, typeComputer, isFunctional);
-        this.isPrivate = isPrivate;
+        super(fi, typeComputer, isFunctional, isPrivate);
     }
 
-    public boolean isPrivate() {
-        return isPrivate;
-    }
 }

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/om/functions/ExternalFunctionInfo.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/om/functions/ExternalFunctionInfo.java
@@ -30,7 +30,7 @@ import org.apache.hyracks.algebricks.core.algebra.functions.FunctionIdentifier;
 
 public class ExternalFunctionInfo extends FunctionInfo implements IExternalFunctionInfo {
 
-    private static final long serialVersionUID = 5L;
+    private static final long serialVersionUID = 6L;
 
     private final FunctionKind kind;
     private final List<IAType> parameterTypes;
@@ -45,8 +45,8 @@ public class ExternalFunctionInfo extends FunctionInfo implements IExternalFunct
     public ExternalFunctionInfo(FunctionIdentifier fid, FunctionKind kind, List<IAType> parameterTypes,
             IAType returnType, IResultTypeComputer rtc, ExternalFunctionLanguage language,
             DataverseName libraryDataverseName, String libraryName, List<String> externalIdentifier,
-            Map<String, String> resources, boolean deterministic, boolean nullCall) {
-        super(fid, rtc, deterministic);
+            Map<String, String> resources, boolean deterministic, boolean nullCall, boolean isPrivate) {
+        super(fid, rtc, deterministic, isPrivate);
         this.kind = kind;
         this.parameterTypes = parameterTypes;
         this.returnType = returnType;
@@ -100,5 +100,10 @@ public class ExternalFunctionInfo extends FunctionInfo implements IExternalFunct
     @Override
     public boolean getNullCall() {
         return nullCall;
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return super.isPrivate();
     }
 }

--- a/asterixdb/asterix-om/src/main/java/org/apache/asterix/om/functions/FunctionInfo.java
+++ b/asterixdb/asterix-om/src/main/java/org/apache/asterix/om/functions/FunctionInfo.java
@@ -29,15 +29,18 @@ import org.apache.hyracks.algebricks.core.algebra.functions.IFunctionInfo;
 
 public abstract class FunctionInfo implements IFunctionInfo {
     private static final long serialVersionUID = 5460606629941107899L;
+    protected final boolean isPrivate;
 
     private final FunctionIdentifier functionIdentifier;
     private final transient IResultTypeComputer typeComputer;
     private final boolean isFunctional;
 
-    public FunctionInfo(FunctionIdentifier functionIdentifier, IResultTypeComputer typeComputer, boolean isFunctional) {
+    public FunctionInfo(FunctionIdentifier functionIdentifier, IResultTypeComputer typeComputer, boolean isFunctional,
+            boolean isPrivate) {
         this.functionIdentifier = Objects.requireNonNull(functionIdentifier);
         this.typeComputer = typeComputer;
         this.isFunctional = isFunctional;
+        this.isPrivate = isPrivate;
     }
 
     @Override
@@ -67,5 +70,10 @@ public abstract class FunctionInfo implements IFunctionInfo {
     @Override
     public String toString() {
         return functionIdentifier.toString();
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return isPrivate;
     }
 }

--- a/hyracks-fullstack/algebricks/algebricks-core/src/main/java/org/apache/hyracks/algebricks/core/algebra/functions/IFunctionInfo.java
+++ b/hyracks-fullstack/algebricks/algebricks-core/src/main/java/org/apache/hyracks/algebricks/core/algebra/functions/IFunctionInfo.java
@@ -58,4 +58,6 @@ public interface IFunctionInfo extends Serializable {
         sb.append(")");
         return sb.toString();
     }
+
+    boolean isPrivate();
 }


### PR DESCRIPTION
still need to call different wrappings of the UDA on step1/step2. step1 works properly. step2 fails because it should call something else... basically the merge() in the revised API